### PR TITLE
Refractoring

### DIFF
--- a/server/_install.sh
+++ b/server/_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INSTALLER_VERSION="0.5.0.33"
 MC_VERSION="1.14.4"
@@ -21,18 +21,26 @@ else
   echo "fabric-server-launch.jar and server.jar found"
 fi
 
-echo "#!/bin/sh" > start.sh
-echo "java -Xms2499M -Xmx2500M -jar fabric-server-launch.jar" nogui >> start.sh
-echo 'read -n1 -r -p "Press any key to continue..."' >> start.sh
+cat > start.sh <<EOF
+#!/usr/bin/env bash
 
-echo "#!/bin/sh" > start_autorestart.sh
-echo "while true" >> start_autorestart.sh
-echo "do" >> start_autorestart.sh
-echo "java -Xms2499M -Xmx2500M -jar fabric-server-launch.jar" nogui >> start_autorestart.sh
-echo 'echo "Crashed? Restarting in 10 seconds..."' >> start_autorestart.sh
-echo "sleep 10" >> start_autorestart.sh
-echo "done" >> start_autorestart.sh
-echo 'read -n1 -r -p "Press any key to continue..."' >> start_autorestart.sh
+java -Xms2499M -Xmx2500M -jar fabric-server-launch.jar nogui
+
+read -n1 -r -p "Press any key to continue..."
+EOF
+
+cat > start_autorestart.sh <<EOF
+#!/usr/bin/env bash
+
+while true
+do
+  java -Xms2499M -Xmx2500M -jar fabric-server-launch.jar nogui
+  echo "Crashed? Restarting in 10 seconds..."
+  sleep 10
+done
+
+read -n1 -r -p "Press any key to continue..."
+EOF
 
 echo "eula=true" > eula.txt
 

--- a/server/_install.sh
+++ b/server/_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INSTALLER_VERSION="0.5.0.33"
 MC_VERSION="1.14.4"
@@ -22,7 +22,7 @@ else
 fi
 
 cat > start.sh <<EOF
-#!/bin/bash
+#!/bin/sh
 
 java -Xms2499M -Xmx2500M -jar fabric-server-launch.jar nogui
 
@@ -30,7 +30,7 @@ read -n1 -r -p "Press any key to continue..."
 EOF
 
 cat > start_autorestart.sh <<EOF
-#!/bin/bash
+#!/bin/sh
 
 while true
 do

--- a/server/_install.sh
+++ b/server/_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 INSTALLER_VERSION="0.5.0.33"
 MC_VERSION="1.14.4"
@@ -22,7 +22,7 @@ else
 fi
 
 cat > start.sh <<EOF
-#!/usr/bin/env bash
+#!/bin/bash
 
 java -Xms2499M -Xmx2500M -jar fabric-server-launch.jar nogui
 
@@ -30,7 +30,7 @@ read -n1 -r -p "Press any key to continue..."
 EOF
 
 cat > start_autorestart.sh <<EOF
-#!/usr/bin/env bash
+#!/bin/bash
 
 while true
 do

--- a/server/_install_mods.sh
+++ b/server/_install_mods.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 cd "$(dirname "$0")" || exit
 mkdir -p mods || exit
 cd mods || exit

--- a/server/_install_mods.sh
+++ b/server/_install_mods.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit
 mkdir -p mods || exit
 cd mods || exit

--- a/server/_install_mods.sh
+++ b/server/_install_mods.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 cd "$(dirname "$0")" || exit
 mkdir -p mods || exit
 cd mods || exit


### PR DESCRIPTION
changed `#!/bin/bash` to `#!/usr/bin/env bash` (see [here](https://github.com/dylanaraps/pure-bash-bible#obsolete-syntax) why)

Using cat instead of echo to write files with more than one line